### PR TITLE
Fix validation for Finnish vat numbers

### DIFF
--- a/pyVat/validators/fi.py
+++ b/pyVat/validators/fi.py
@@ -40,10 +40,9 @@ class Validator(GenericValidator):
         checksum = int(vat_number[7])
 
         r = 11 - self.sum_weights([7,9,10,5,8,4,2], vat_number) % 11
-        if r == 0:
+        if r == 10:
             return False
-        elif r == 11:
-            if checksum != 0:
-                return False
+        elif (r == 11 and checksum == 0) or checksum == r:
+            return True
         else:
-            return checksum == r
+            return False


### PR DESCRIPTION
Fixing a bug in the validate method in fi.py. Previous code returns None when checksum == 0. E.g. FI19506810 is a valid Finnish vat number, but validate() returns None.